### PR TITLE
temp fix for compiling under debian testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         textscreen
         asound
         SDL2::SDL2
-        SDL2::SDL2main
         )
 
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
libsdl2-dev and all libsdl2* packages don't have anything related to SDL2main on the repository.